### PR TITLE
Decode utf-8-sig files

### DIFF
--- a/wagtailimportexport/views.py
+++ b/wagtailimportexport/views.py
@@ -78,7 +78,7 @@ def import_from_file(request):
     if request.method == 'POST':
         form = ImportFromFileForm(request.POST, request.FILES)
         if form.is_valid():
-            import_data = json.loads(form.cleaned_data['file'].read().decode('utf-8'))
+            import_data = json.loads(form.cleaned_data['file'].read().decode('utf-8-sig'))
             parent_page = form.cleaned_data['parent_page']
 
             try:


### PR DESCRIPTION
We are having some issues when a user saves its files with Notepad or another text editor that by default saves in an UTF-8 with BOM format.

Added support to utf-8-sig files by just decoding to this format.

Tested it with files in the utf-8 standard format and with BOM.