### PR TITLE
Add compat module and extract backwards compatibility imports

### DIFF
--- a/wagtailimportexport/compat.py
+++ b/wagtailimportexport/compat.py
@@ -1,0 +1,16 @@
+try:
+    from wagtail.admin import messages
+    from wagtail.admin.menu import MenuItem
+    from wagtail.admin.widgets import AdminPageChooser
+    from wagtail.core import hooks
+    from wagtail.core.models import Page
+
+    WAGTAIL_VERSION_2_OR_GREATER = True
+except ImportError:  # fallback for Wagtail <2.0
+    from wagtail.wagtailadmin import messages
+    from wagtail.wagtailadmin.menu import MenuItem
+    from wagtail.wagtailadmin.widgets import AdminPageChooser
+    from wagtail.wagtailcore import hooks
+    from wagtail.wagtailcore.models import Page
+
+    WAGTAIL_VERSION_2_OR_GREATER = False

--- a/wagtailimportexport/exporting.py
+++ b/wagtailimportexport/exporting.py
@@ -1,9 +1,6 @@
 import json
 
-try:
-    from wagtail.core.models import Page
-except ImportError:  # fallback for Wagtail <2.0
-    from wagtail.wagtailcore.models import Page
+from wagtailimportexport.compat import Page
 
 
 def export_pages(root_page, export_unpublished=False):

--- a/wagtailimportexport/forms.py
+++ b/wagtailimportexport/forms.py
@@ -1,18 +1,7 @@
 from django import forms
 from django.utils.translation import ugettext as _
 
-
-WAGTAIL_VERSION_2_OR_GREATER = True
-
-
-try:
-    from wagtail.admin.widgets import AdminPageChooser
-    from wagtail.core.models import Page
-except ImportError:  # fallback for Wagtail <2.0
-    from wagtail.wagtailadmin.widgets import AdminPageChooser
-    from wagtail.wagtailcore.models import Page
-
-    WAGTAIL_VERSION_2_OR_GREATER = False
+from wagtailimportexport.compat import AdminPageChooser, Page, WAGTAIL_VERSION_2_OR_GREATER
 
 
 admin_page_params = {

--- a/wagtailimportexport/importing.py
+++ b/wagtailimportexport/importing.py
@@ -3,10 +3,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import models, transaction
 from modelcluster.models import get_all_child_relations
 
-try:
-    from wagtail.core.models import Page
-except ImportError:  # fallback for Wagtail <2.0
-    from wagtail.wagtailcore.models import Page
+from wagtailimportexport.compat import Page
 
 
 @transaction.atomic()

--- a/wagtailimportexport/views.py
+++ b/wagtailimportexport/views.py
@@ -8,13 +8,7 @@ from django.utils.translation import ungettext, ugettext_lazy as _
 
 import requests
 
-try:
-    from wagtail.admin import messages
-    from wagtail.core.models import Page
-except ImportError:  # fallback for Wagtail <2.0
-    from wagtail.wagtailadmin import messages
-    from wagtail.wagtailcore.models import Page
-
+from wagtailimportexport.compat import messages, Page
 from wagtailimportexport.exporting import export_pages
 from wagtailimportexport.forms import ExportForm, ImportFromAPIForm, ImportFromFileForm
 from wagtailimportexport.importing import import_pages

--- a/wagtailimportexport/wagtail_hooks.py
+++ b/wagtailimportexport/wagtail_hooks.py
@@ -2,14 +2,8 @@ from django.conf.urls import include, url
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
-try:
-    from wagtail.admin.menu import MenuItem
-    from wagtail.core import hooks
-except ImportError:  # fallback for Wagtail <2.0
-    from wagtail.wagtailadmin.menu import MenuItem
-    from wagtail.wagtailcore import hooks
-
 from wagtailimportexport import admin_urls
+from wagtailimportexport.compat import hooks, MenuItem
 
 
 @hooks.register('register_admin_urls')


### PR DESCRIPTION
This PR creates `compat` module which is supposed to keep all compatibility imports and avoid import cluttering like

```python
try:
    from wagtail.admin import messages
    from wagtail.admin.menu import MenuItem
except ImportError:  # fallback for Wagtail <2.0
    ...
```